### PR TITLE
Use Locale.ROOT for locale neutral, case insensitive comparisons

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/support/PropertyComparator.java
+++ b/spring-beans/src/main/java/org/springframework/beans/support/PropertyComparator.java
@@ -19,6 +19,7 @@ package org.springframework.beans.support;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -77,8 +78,8 @@ public class PropertyComparator<T> implements Comparator<T> {
 		Object v1 = getPropertyValue(o1);
 		Object v2 = getPropertyValue(o2);
 		if (this.sortDefinition.isIgnoreCase() && (v1 instanceof String) && (v2 instanceof String)) {
-			v1 = ((String) v1).toLowerCase();
-			v2 = ((String) v2).toLowerCase();
+			v1 = ((String) v1).toLowerCase(Locale.ROOT);
+			v2 = ((String) v2).toLowerCase(Locale.ROOT);
 		}
 
 		int result;

--- a/spring-context-support/src/main/java/org/springframework/scheduling/quartz/LocalDataSourceJobStore.java
+++ b/spring-context-support/src/main/java/org/springframework/scheduling/quartz/LocalDataSourceJobStore.java
@@ -19,6 +19,7 @@ package org.springframework.scheduling.quartz;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
+import java.util.Locale;
 
 import javax.sql.DataSource;
 
@@ -155,7 +156,7 @@ public class LocalDataSourceJobStore extends JobStoreCMT {
 			String productName = JdbcUtils.extractDatabaseMetaData(this.dataSource,
 					DatabaseMetaData::getDatabaseProductName);
 			productName = JdbcUtils.commonDatabaseName(productName);
-			if (productName != null && productName.toLowerCase().contains("hsql")) {
+			if (productName != null && productName.toLowerCase(Locale.ROOT).contains("hsql")) {
 				setUseDBLocks(false);
 				setLockHandler(new SimpleSemaphore());
 			}

--- a/spring-context/src/main/java/org/springframework/format/datetime/standard/MonthFormatter.java
+++ b/spring-context/src/main/java/org/springframework/format/datetime/standard/MonthFormatter.java
@@ -34,7 +34,7 @@ class MonthFormatter implements Formatter<Month> {
 
 	@Override
 	public Month parse(String text, Locale locale) throws ParseException {
-		return Month.valueOf(text.toUpperCase());
+		return Month.valueOf(text.toUpperCase(Locale.ROOT));
 	}
 
 	@Override

--- a/spring-context/src/main/java/org/springframework/scheduling/support/CronField.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/support/CronField.java
@@ -21,6 +21,7 @@ import java.time.temporal.ChronoField;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.Temporal;
 import java.time.temporal.ValueRange;
+import java.util.Locale;
 import java.util.function.BiFunction;
 
 import org.springframework.lang.Nullable;
@@ -143,7 +144,7 @@ abstract class CronField {
 	}
 
 	private static String replaceOrdinals(String value, String[] list) {
-		value = value.toUpperCase();
+		value = value.toUpperCase(Locale.ROOT);
 		for (int i = 0; i < list.length; i++) {
 			String replacement = Integer.toString(i + 1);
 			value = StringUtils.replace(value, list[i], replacement);

--- a/spring-context/src/main/java/org/springframework/scheduling/support/CronSequenceGenerator.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/support/CronSequenceGenerator.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
+import java.util.Locale;
 import java.util.TimeZone;
 
 import org.springframework.lang.Nullable;
@@ -305,8 +306,8 @@ public class CronSequenceGenerator {
 	private String replaceOrdinals(String value, String commaSeparatedList) {
 		String[] list = StringUtils.commaDelimitedListToStringArray(commaSeparatedList);
 		for (int i = 0; i < list.length; i++) {
-			String item = list[i].toUpperCase();
-			value = StringUtils.replace(value.toUpperCase(), item, "" + i);
+			String item = list[i].toUpperCase(Locale.ROOT);
+			value = StringUtils.replace(value.toUpperCase(Locale.ROOT), item, "" + i);
 		}
 		return value;
 	}

--- a/spring-context/src/main/java/org/springframework/validation/DataBinder.java
+++ b/spring-context/src/main/java/org/springframework/validation/DataBinder.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.apache.commons.logging.Log;
@@ -482,7 +483,8 @@ public class DataBinder implements PropertyEditorRegistry, TypeConverter {
 		else {
 			String[] fieldPatterns = new String[disallowedFields.length];
 			for (int i = 0; i < fieldPatterns.length; i++) {
-				fieldPatterns[i] = PropertyAccessorUtils.canonicalPropertyName(disallowedFields[i]).toLowerCase();
+				String field = PropertyAccessorUtils.canonicalPropertyName(disallowedFields[i]);
+				fieldPatterns[i] = field.toLowerCase(Locale.ROOT);
 			}
 			this.disallowedFields = fieldPatterns;
 		}
@@ -825,7 +827,7 @@ public class DataBinder implements PropertyEditorRegistry, TypeConverter {
 		String[] allowed = getAllowedFields();
 		String[] disallowed = getDisallowedFields();
 		return ((ObjectUtils.isEmpty(allowed) || PatternMatchUtils.simpleMatch(allowed, field)) &&
-				(ObjectUtils.isEmpty(disallowed) || !PatternMatchUtils.simpleMatch(disallowed, field.toLowerCase())));
+				(ObjectUtils.isEmpty(disallowed) || !PatternMatchUtils.simpleMatch(disallowed, field.toLowerCase(Locale.ROOT))));
 	}
 
 	/**

--- a/spring-core/src/main/java/org/springframework/core/convert/support/StringToBooleanConverter.java
+++ b/spring-core/src/main/java/org/springframework/core/convert/support/StringToBooleanConverter.java
@@ -17,6 +17,7 @@
 package org.springframework.core.convert.support;
 
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
 
 import org.springframework.core.convert.converter.Converter;
@@ -55,7 +56,7 @@ final class StringToBooleanConverter implements Converter<String, Boolean> {
 		if (value.isEmpty()) {
 			return null;
 		}
-		value = value.toLowerCase();
+		value = value.toLowerCase(Locale.ROOT);
 		if (trueValues.contains(value)) {
 			return Boolean.TRUE;
 		}

--- a/spring-core/src/main/java/org/springframework/core/env/SystemEnvironmentPropertySource.java
+++ b/spring-core/src/main/java/org/springframework/core/env/SystemEnvironmentPropertySource.java
@@ -16,6 +16,7 @@
 
 package org.springframework.core.env;
 
+import java.util.Locale;
 import java.util.Map;
 
 import org.springframework.lang.Nullable;
@@ -109,7 +110,7 @@ public class SystemEnvironmentPropertySource extends MapPropertySource {
 		if (resolvedName != null) {
 			return resolvedName;
 		}
-		String uppercasedName = name.toUpperCase();
+		String uppercasedName = name.toUpperCase(Locale.ROOT);
 		if (!name.equals(uppercasedName)) {
 			resolvedName = checkPropertyName(uppercasedName);
 			if (resolvedName != null) {

--- a/spring-core/src/main/java/org/springframework/util/MimeType.java
+++ b/spring-core/src/main/java/org/springframework/util/MimeType.java
@@ -182,10 +182,10 @@ public class MimeType implements Comparable<MimeType>, Serializable {
 		Assert.hasLength(subtype, "'subtype' must not be empty");
 		checkToken(type);
 		checkToken(subtype);
-		this.type = type.toLowerCase(Locale.ENGLISH);
-		this.subtype = subtype.toLowerCase(Locale.ENGLISH);
+		this.type = type.toLowerCase(Locale.ROOT);
+		this.subtype = subtype.toLowerCase(Locale.ROOT);
 		if (!CollectionUtils.isEmpty(parameters)) {
-			Map<String, String> map = new LinkedCaseInsensitiveMap<>(parameters.size(), Locale.ENGLISH);
+			Map<String, String> map = new LinkedCaseInsensitiveMap<>(parameters.size(), Locale.ROOT);
 			parameters.forEach((parameter, value) -> {
 				checkParameters(parameter, value);
 				map.put(parameter, value);

--- a/spring-core/src/main/java/org/springframework/util/ResourceUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/ResourceUtils.java
@@ -23,6 +23,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.util.Locale;
 
 import org.springframework.lang.Nullable;
 
@@ -295,7 +296,7 @@ public abstract class ResourceUtils {
 	 */
 	public static boolean isJarFileURL(URL url) {
 		return (URL_PROTOCOL_FILE.equals(url.getProtocol()) &&
-				url.getPath().toLowerCase().endsWith(JAR_FILE_EXTENSION));
+				url.getPath().toLowerCase(Locale.ROOT).endsWith(JAR_FILE_EXTENSION));
 	}
 
 	/**

--- a/spring-expression/src/main/java/org/springframework/expression/spel/SpelParserConfiguration.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/SpelParserConfiguration.java
@@ -16,6 +16,8 @@
 
 package org.springframework.expression.spel;
 
+import java.util.Locale;
+
 import org.springframework.core.SpringProperties;
 import org.springframework.lang.Nullable;
 
@@ -45,7 +47,7 @@ public class SpelParserConfiguration {
 	static {
 		String compilerMode = SpringProperties.getProperty(SPRING_EXPRESSION_COMPILER_MODE_PROPERTY_NAME);
 		defaultCompilerMode = (compilerMode != null ?
-				SpelCompilerMode.valueOf(compilerMode.toUpperCase()) : SpelCompilerMode.OFF);
+				SpelCompilerMode.valueOf(compilerMode.toUpperCase(Locale.ROOT)) : SpelCompilerMode.OFF);
 	}
 
 

--- a/spring-expression/src/main/java/org/springframework/expression/spel/ast/TypeReference.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/ast/TypeReference.java
@@ -17,6 +17,7 @@
 package org.springframework.expression.spel.ast;
 
 import java.lang.reflect.Array;
+import java.util.Locale;
 
 import org.springframework.asm.MethodVisitor;
 import org.springframework.asm.Type;
@@ -57,7 +58,7 @@ public class TypeReference extends SpelNodeImpl {
 		String typeName = (String) this.children[0].getValueInternal(state).getValue();
 		Assert.state(typeName != null, "No type name");
 		if (!typeName.contains(".") && Character.isLowerCase(typeName.charAt(0))) {
-			TypeCode tc = TypeCode.valueOf(typeName.toUpperCase());
+			TypeCode tc = TypeCode.valueOf(typeName.toUpperCase(Locale.ROOT));
 			if (tc != TypeCode.OBJECT) {
 				// It is a primitive type
 				Class<?> clazz = makeArrayIfNecessary(tc.getType());

--- a/spring-expression/src/main/java/org/springframework/expression/spel/standard/InternalSpelExpressionParser.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/standard/InternalSpelExpressionParser.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.regex.Pattern;
@@ -750,7 +751,7 @@ class InternalSpelExpressionParser extends TemplateAwareExpressionParser {
 				throw internalException( this.expressionString.length(), SpelMessage.OOD);
 			}
 			throw internalException(node.startPos, SpelMessage.NOT_EXPECTED_TOKEN,
-					"qualified ID", node.getKind().toString().toLowerCase());
+					"qualified ID", node.getKind().toString().toLowerCase(Locale.ROOT));
 		}
 		return new QualifiedIdentifier(qualifiedIdPieces.getFirst().getStartPosition(),
 				qualifiedIdPieces.getLast().getEndPosition(), qualifiedIdPieces.toArray(new SpelNodeImpl[0]));
@@ -942,7 +943,7 @@ class InternalSpelExpressionParser extends TemplateAwareExpressionParser {
 		}
 		if (t.kind != expectedKind) {
 			throw internalException(t.startPos, SpelMessage.NOT_EXPECTED_TOKEN,
-					expectedKind.toString().toLowerCase(), t.getKind().toString().toLowerCase());
+					expectedKind.toString().toLowerCase(Locale.ROOT), t.getKind().toString().toLowerCase(Locale.ROOT));
 		}
 		return t;
 	}
@@ -1038,7 +1039,7 @@ class InternalSpelExpressionParser extends TemplateAwareExpressionParser {
 		if (t.getKind().hasPayload()) {
 			return t.stringValue();
 		}
-		return t.kind.toString().toLowerCase();
+		return t.kind.toString().toLowerCase(Locale.ROOT);
 	}
 
 	private void checkOperands(Token token, @Nullable SpelNodeImpl left, @Nullable SpelNodeImpl right) {

--- a/spring-expression/src/main/java/org/springframework/expression/spel/standard/Tokenizer.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/standard/Tokenizer.java
@@ -19,6 +19,7 @@ package org.springframework.expression.spel.standard;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 
 import org.springframework.expression.spel.InternalParseException;
 import org.springframework.expression.spel.SpelMessage;
@@ -455,7 +456,7 @@ class Tokenizer {
 		// Check if this is the alternative (textual) representation of an operator (see
 		// alternativeOperatorNames)
 		if ((this.pos - start) == 2 || (this.pos - start) == 3) {
-			String asString = new String(subarray).toUpperCase();
+			String asString = new String(subarray).toUpperCase(Locale.ROOT);
 			int idx = Arrays.binarySearch(ALTERNATIVE_OPERATOR_NAMES, asString);
 			if (idx >= 0) {
 				pushOneCharOrTwoCharToken(TokenKind.valueOf(asString), start, subarray);

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/CallMetaDataContext.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/CallMetaDataContext.java
@@ -385,7 +385,7 @@ public class CallMetaDataContext {
 				if (meta.isReturnParameter()) {
 					param = declaredParams.get(getFunctionReturnName());
 					if (param == null && !getOutParameterNames().isEmpty()) {
-						param = declaredParams.get(getOutParameterNames().get(0).toLowerCase());
+						param = declaredParams.get(getOutParameterNames().get(0).toLowerCase(Locale.ROOT));
 					}
 					if (param == null) {
 						throw new InvalidDataAccessApiUsageException(
@@ -488,7 +488,7 @@ public class CallMetaDataContext {
 				String parameterName = parameter.getName();
 				String parameterNameToMatch = obtainMetaDataProvider().parameterNameToUse(parameterName);
 				if (parameterNameToMatch != null) {
-					callParameterNames.put(parameterNameToMatch.toLowerCase(), parameterName);
+					callParameterNames.put(parameterNameToMatch.toLowerCase(Locale.ROOT), parameterName);
 				}
 				if (parameterName != null) {
 					if (parameterSource.hasValue(parameterName)) {
@@ -496,7 +496,7 @@ public class CallMetaDataContext {
 								SqlParameterSourceUtils.getTypedValue(parameterSource, parameterName));
 					}
 					else {
-						String lowerCaseName = parameterName.toLowerCase();
+						String lowerCaseName = parameterName.toLowerCase(Locale.ROOT);
 						if (parameterSource.hasValue(lowerCaseName)) {
 							matchedParameters.put(parameterName,
 									SqlParameterSourceUtils.getTypedValue(parameterSource, lowerCaseName));
@@ -556,7 +556,7 @@ public class CallMetaDataContext {
 				String parameterName = parameter.getName();
 				String parameterNameToMatch = provider.parameterNameToUse(parameterName);
 				if (parameterNameToMatch != null) {
-					callParameterNames.put(parameterNameToMatch.toLowerCase(), parameterName);
+					callParameterNames.put(parameterNameToMatch.toLowerCase(Locale.ROOT), parameterName);
 				}
 			}
 		}
@@ -680,7 +680,7 @@ public class CallMetaDataContext {
 	}
 
 	private static String lowerCase(@Nullable String paramName) {
-		return (paramName != null ? paramName.toLowerCase() : "");
+		return (paramName != null ? paramName.toLowerCase(Locale.ROOT) : "");
 	}
 
 }

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/Db2CallMetaDataProvider.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/Db2CallMetaDataProvider.java
@@ -18,6 +18,7 @@ package org.springframework.jdbc.core.metadata;
 
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
+import java.util.Locale;
 
 import org.springframework.lang.Nullable;
 
@@ -73,7 +74,7 @@ public class Db2CallMetaDataProvider extends GenericCallMetaDataProvider {
 
 		// Use current user schema if no schema specified...
 		String userName = getUserName();
-		return (userName != null ? userName.toUpperCase() : null);
+		return (userName != null ? userName.toUpperCase(Locale.ROOT) : null);
 	}
 
 }

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/DerbyCallMetaDataProvider.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/DerbyCallMetaDataProvider.java
@@ -18,6 +18,7 @@ package org.springframework.jdbc.core.metadata;
 
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
+import java.util.Locale;
 
 import org.springframework.lang.Nullable;
 
@@ -45,7 +46,7 @@ public class DerbyCallMetaDataProvider extends GenericCallMetaDataProvider {
 
 		// Use current user schema if no schema specified...
 		String userName = getUserName();
-		return (userName != null ? userName.toUpperCase() : null);
+		return (userName != null ? userName.toUpperCase(Locale.ROOT) : null);
 	}
 
 }

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/GenericCallMetaDataProvider.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/GenericCallMetaDataProvider.java
@@ -22,6 +22,7 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -279,10 +280,10 @@ public class GenericCallMetaDataProvider implements CallMetaDataProvider {
 			return null;
 		}
 		else if (isStoresUpperCaseIdentifiers()) {
-			return identifierName.toUpperCase();
+			return identifierName.toUpperCase(Locale.ROOT);
 		}
 		else if (isStoresLowerCaseIdentifiers()) {
-			return identifierName.toLowerCase();
+			return identifierName.toLowerCase(Locale.ROOT);
 		}
 		else {
 			return identifierName;

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/GenericTableMetaDataProvider.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/GenericTableMetaDataProvider.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.apache.commons.logging.Log;
@@ -230,10 +231,10 @@ public class GenericTableMetaDataProvider implements TableMetaDataProvider {
 			return null;
 		}
 		else if (isStoresUpperCaseIdentifiers()) {
-			return tableName.toUpperCase();
+			return tableName.toUpperCase(Locale.ROOT);
 		}
 		else if (isStoresLowerCaseIdentifiers()) {
-			return tableName.toLowerCase();
+			return tableName.toLowerCase(Locale.ROOT);
 		}
 		else {
 			return tableName;
@@ -247,10 +248,10 @@ public class GenericTableMetaDataProvider implements TableMetaDataProvider {
 			return null;
 		}
 		else if (isStoresUpperCaseIdentifiers()) {
-			return catalogName.toUpperCase();
+			return catalogName.toUpperCase(Locale.ROOT);
 		}
 		else if (isStoresLowerCaseIdentifiers()) {
-			return catalogName.toLowerCase();
+			return catalogName.toLowerCase(Locale.ROOT);
 		}
 		else {
 			return catalogName;
@@ -264,10 +265,10 @@ public class GenericTableMetaDataProvider implements TableMetaDataProvider {
 			return null;
 		}
 		else if (isStoresUpperCaseIdentifiers()) {
-			return schemaName.toUpperCase();
+			return schemaName.toUpperCase(Locale.ROOT);
 		}
 		else if (isStoresLowerCaseIdentifiers()) {
-			return schemaName.toLowerCase();
+			return schemaName.toLowerCase(Locale.ROOT);
 		}
 		else {
 			return schemaName;
@@ -322,10 +323,10 @@ public class GenericTableMetaDataProvider implements TableMetaDataProvider {
 				tmd.setSchemaName(tables.getString("TABLE_SCHEM"));
 				tmd.setTableName(tables.getString("TABLE_NAME"));
 				if (tmd.getSchemaName() == null) {
-					tableMeta.put(this.userName != null ? this.userName.toUpperCase() : "", tmd);
+					tableMeta.put(this.userName != null ? this.userName.toUpperCase(Locale.ROOT) : "", tmd);
 				}
 				else {
-					tableMeta.put(tmd.getSchemaName().toUpperCase(), tmd);
+					tableMeta.put(tmd.getSchemaName().toUpperCase(Locale.ROOT), tmd);
 				}
 			}
 		}
@@ -352,7 +353,7 @@ public class GenericTableMetaDataProvider implements TableMetaDataProvider {
 			Map<String, TableMetaData> tableMeta) {
 
 		if (schemaName != null) {
-			TableMetaData tmd = tableMeta.get(schemaName.toUpperCase());
+			TableMetaData tmd = tableMeta.get(schemaName.toUpperCase(Locale.ROOT));
 			if (tmd == null) {
 				throw new DataAccessResourceFailureException("Unable to locate table meta-data for '" +
 						tableName + "' in the '" + schemaName + "' schema");
@@ -365,7 +366,7 @@ public class GenericTableMetaDataProvider implements TableMetaDataProvider {
 		else {
 			TableMetaData tmd = tableMeta.get(getDefaultSchema());
 			if (tmd == null) {
-				tmd = tableMeta.get(this.userName != null ? this.userName.toUpperCase() : "");
+				tmd = tableMeta.get(this.userName != null ? this.userName.toUpperCase(Locale.ROOT) : "");
 			}
 			if (tmd == null) {
 				tmd = tableMeta.get("PUBLIC");

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/TableMetaDataContext.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/TableMetaDataContext.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -192,11 +193,11 @@ public class TableMetaDataContext {
 		}
 		Set<String> keys = new LinkedHashSet<>(generatedKeyNames.length);
 		for (String key : generatedKeyNames) {
-			keys.add(key.toUpperCase());
+			keys.add(key.toUpperCase(Locale.ROOT));
 		}
 		List<String> columns = new ArrayList<>();
 		for (TableParameterMetaData meta : obtainMetaDataProvider().getTableParameterMetaData()) {
-			if (!keys.contains(meta.getParameterName().toUpperCase())) {
+			if (!keys.contains(meta.getParameterName().toUpperCase(Locale.ROOT))) {
 				columns.add(meta.getParameterName());
 			}
 		}
@@ -218,7 +219,7 @@ public class TableMetaDataContext {
 				values.add(SqlParameterSourceUtils.getTypedValue(parameterSource, column));
 			}
 			else {
-				String lowerCaseName = column.toLowerCase();
+				String lowerCaseName = column.toLowerCase(Locale.ROOT);
 				if (parameterSource.hasValue(lowerCaseName)) {
 					values.add(SqlParameterSourceUtils.getTypedValue(parameterSource, lowerCaseName));
 				}
@@ -251,7 +252,7 @@ public class TableMetaDataContext {
 		for (String column : this.tableColumns) {
 			Object value = inParameters.get(column);
 			if (value == null) {
-				value = inParameters.get(column.toLowerCase());
+				value = inParameters.get(column.toLowerCase(Locale.ROOT));
 				if (value == null) {
 					for (Map.Entry<String, ?> entry : inParameters.entrySet()) {
 						if (column.equalsIgnoreCase(entry.getKey())) {
@@ -274,7 +275,7 @@ public class TableMetaDataContext {
 	public String createInsertString(String... generatedKeyNames) {
 		Set<String> keys = new LinkedHashSet<>(generatedKeyNames.length);
 		for (String key : generatedKeyNames) {
-			keys.add(key.toUpperCase());
+			keys.add(key.toUpperCase(Locale.ROOT));
 		}
 		StringBuilder insertStatement = new StringBuilder();
 		insertStatement.append("INSERT INTO ");
@@ -286,7 +287,7 @@ public class TableMetaDataContext {
 		insertStatement.append(" (");
 		int columnCount = 0;
 		for (String columnName : getTableColumns()) {
-			if (!keys.contains(columnName.toUpperCase())) {
+			if (!keys.contains(columnName.toUpperCase(Locale.ROOT))) {
 				columnCount++;
 				if (columnCount > 1) {
 					insertStatement.append(", ");
@@ -326,7 +327,7 @@ public class TableMetaDataContext {
 		List<TableParameterMetaData> parameters = obtainMetaDataProvider().getTableParameterMetaData();
 		Map<String, TableParameterMetaData> parameterMap = CollectionUtils.newLinkedHashMap(parameters.size());
 		for (TableParameterMetaData tpmd : parameters) {
-			parameterMap.put(tpmd.getParameterName().toUpperCase(), tpmd);
+			parameterMap.put(tpmd.getParameterName().toUpperCase(Locale.ROOT), tpmd);
 		}
 		int typeIndx = 0;
 		for (String column : getTableColumns()) {
@@ -334,7 +335,7 @@ public class TableMetaDataContext {
 				types[typeIndx] = SqlTypeValue.TYPE_UNKNOWN;
 			}
 			else {
-				TableParameterMetaData tpmd = parameterMap.get(column.toUpperCase());
+				TableParameterMetaData tpmd = parameterMap.get(column.toUpperCase(Locale.ROOT));
 				if (tpmd != null) {
 					types[typeIndx] = tpmd.getSqlType();
 				}

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/namedparam/SqlParameterSourceUtils.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/namedparam/SqlParameterSourceUtils.java
@@ -19,6 +19,7 @@ package org.springframework.jdbc.core.namedparam;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 import org.springframework.jdbc.core.SqlParameterValue;
@@ -115,7 +116,7 @@ public abstract class SqlParameterSourceUtils {
 		String[] paramNames = parameterSource.getParameterNames();
 		if (paramNames != null) {
 			for (String name : paramNames) {
-				caseInsensitiveParameterNames.put(name.toLowerCase(), name);
+				caseInsensitiveParameterNames.put(name.toLowerCase(Locale.ROOT), name);
 			}
 		}
 		return caseInsensitiveParameterNames;

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/AbstractJdbcInsert.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/AbstractJdbcInsert.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import javax.sql.DataSource;
@@ -463,7 +464,7 @@ public abstract class AbstractJdbcInsert {
 			// get generated keys feature. HSQL is one, PostgreSQL is another. Postgres uses a RETURNING
 			// clause while HSQL uses a second query that has to be executed with the same connection.
 
-			if (keyQuery.toUpperCase().startsWith("RETURNING")) {
+			if (keyQuery.toUpperCase(Locale.ROOT).startsWith("RETURNING")) {
 				Long key = getJdbcTemplate().queryForObject(
 						getInsertString() + " " + keyQuery, Long.class, values.toArray());
 				Map<String, Object> keys = new HashMap<>(2);

--- a/spring-jms/src/main/java/org/springframework/jms/config/JmsListenerContainerParser.java
+++ b/spring-jms/src/main/java/org/springframework/jms/config/JmsListenerContainerParser.java
@@ -16,6 +16,8 @@
 
 package org.springframework.jms.config;
 
+import java.util.Locale;
+
 import javax.jms.Session;
 
 import org.w3c.dom.Element;
@@ -154,7 +156,7 @@ class JmsListenerContainerParser extends AbstractListenerContainerParser {
 				}
 			}
 			else {
-				properties.add("cacheLevelName", "CACHE_" + cache.toUpperCase());
+				properties.add("cacheLevelName", "CACHE_" + cache.toUpperCase(Locale.ROOT));
 			}
 		}
 

--- a/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletRequest.java
+++ b/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletRequest.java
@@ -406,7 +406,8 @@ public class MockHttpServletRequest implements HttpServletRequest {
 	private void updateContentTypeHeader() {
 		if (StringUtils.hasLength(this.contentType)) {
 			String value = this.contentType;
-			if (StringUtils.hasLength(this.characterEncoding) && !this.contentType.toLowerCase().contains(CHARSET_PREFIX)) {
+			if (StringUtils.hasLength(this.characterEncoding) &&
+					!this.contentType.toLowerCase(Locale.ROOT).contains(CHARSET_PREFIX)) {
 				value += ';' + CHARSET_PREFIX + this.characterEncoding;
 			}
 			doAddHeaderValue(HttpHeaders.CONTENT_TYPE, value, true);
@@ -484,7 +485,7 @@ public class MockHttpServletRequest implements HttpServletRequest {
 			}
 			catch (IllegalArgumentException ex) {
 				// Try to get charset value anyway
-				int charsetIndex = contentType.toLowerCase().indexOf(CHARSET_PREFIX);
+				int charsetIndex = contentType.toLowerCase(Locale.ROOT).indexOf(CHARSET_PREFIX);
 				if (charsetIndex != -1) {
 					this.characterEncoding = contentType.substring(charsetIndex + CHARSET_PREFIX.length());
 				}

--- a/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletResponse.java
+++ b/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletResponse.java
@@ -215,7 +215,7 @@ public class MockHttpServletResponse implements HttpServletResponse {
 	private void updateContentTypePropertyAndHeader() {
 		if (this.contentType != null) {
 			String value = this.contentType;
-			if (this.characterEncodingSet && !value.toLowerCase().contains(CHARSET_PREFIX)) {
+			if (this.characterEncodingSet && !value.toLowerCase(Locale.ROOT).contains(CHARSET_PREFIX)) {
 				value += ';' + CHARSET_PREFIX + getCharacterEncoding();
 				this.contentType = value;
 			}
@@ -315,7 +315,7 @@ public class MockHttpServletResponse implements HttpServletResponse {
 			}
 			catch (Exception ex) {
 				// Try to get charset value anyway
-				int charsetIndex = contentType.toLowerCase().indexOf(CHARSET_PREFIX);
+				int charsetIndex = contentType.toLowerCase(Locale.ROOT).indexOf(CHARSET_PREFIX);
 				if (charsetIndex != -1) {
 					setExplicitCharacterEncoding(contentType.substring(charsetIndex + CHARSET_PREFIX.length()));
 				}

--- a/spring-test/src/main/java/org/springframework/test/context/NestedTestConfiguration.java
+++ b/spring-test/src/main/java/org/springframework/test/context/NestedTestConfiguration.java
@@ -22,6 +22,7 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.Locale;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -159,7 +160,7 @@ public @interface NestedTestConfiguration {
 				return null;
 			}
 			try {
-				return EnclosingConfiguration.valueOf(name.trim().toUpperCase());
+				return EnclosingConfiguration.valueOf(name.trim().toUpperCase(Locale.ROOT));
 			}
 			catch (IllegalArgumentException ex) {
 				Log logger = LogFactory.getLog(EnclosingConfiguration.class);

--- a/spring-test/src/main/java/org/springframework/test/context/TestConstructor.java
+++ b/spring-test/src/main/java/org/springframework/test/context/TestConstructor.java
@@ -22,6 +22,7 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.Locale;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -151,7 +152,7 @@ public @interface TestConstructor {
 				return null;
 			}
 			try {
-				return AutowireMode.valueOf(name.trim().toUpperCase());
+				return AutowireMode.valueOf(name.trim().toUpperCase(Locale.ROOT));
 			}
 			catch (IllegalArgumentException ex) {
 				Log logger = LogFactory.getLog(AutowireMode.class);

--- a/spring-test/src/main/java/org/springframework/test/context/junit/jupiter/AbstractExpressionEvaluatingCondition.java
+++ b/spring-test/src/main/java/org/springframework/test/context/junit/jupiter/AbstractExpressionEvaluatingCondition.java
@@ -18,6 +18,7 @@ package org.springframework.test.context.junit.jupiter;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -193,7 +194,7 @@ abstract class AbstractExpressionEvaluatingCondition implements ExecutionConditi
 			return (Boolean) result;
 		}
 		else if (result instanceof String) {
-			String str = ((String) result).trim().toLowerCase();
+			String str = ((String) result).trim().toLowerCase(Locale.ROOT);
 			if ("true".equals(str)) {
 				return true;
 			}

--- a/spring-web/src/main/java/org/springframework/http/HttpHeaders.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpHeaders.java
@@ -391,7 +391,7 @@ public class HttpHeaders implements MultiValueMap<String, String>, Serializable 
 	 */
 	public static final HttpHeaders EMPTY = new ReadOnlyHttpHeaders(new LinkedMultiValueMap<>());
 
-	private static final DecimalFormatSymbols DECIMAL_FORMAT_SYMBOLS = new DecimalFormatSymbols(Locale.ENGLISH);
+	private static final DecimalFormatSymbols DECIMAL_FORMAT_SYMBOLS = new DecimalFormatSymbols(Locale.ROOT);
 
 	private static final ZoneId GMT = ZoneId.of("GMT");
 
@@ -420,7 +420,7 @@ public class HttpHeaders implements MultiValueMap<String, String>, Serializable 
 	 * <p>This is the common constructor, using a case-insensitive map structure.
 	 */
 	public HttpHeaders() {
-		this(CollectionUtils.toMultiValueMap(new LinkedCaseInsensitiveMap<>(8, Locale.ENGLISH)));
+		this(CollectionUtils.toMultiValueMap(new LinkedCaseInsensitiveMap<>(8, Locale.ROOT)));
 	}
 
 	/**
@@ -684,7 +684,7 @@ public class HttpHeaders implements MultiValueMap<String, String>, Serializable 
 	public void setAcceptCharset(List<Charset> acceptableCharsets) {
 		StringJoiner joiner = new StringJoiner(", ");
 		for (Charset charset : acceptableCharsets) {
-			joiner.add(charset.name().toLowerCase(Locale.ENGLISH));
+			joiner.add(charset.name().toLowerCase(Locale.ROOT));
 		}
 		set(ACCEPT_CHARSET, joiner.toString());
 	}

--- a/spring-web/src/main/java/org/springframework/http/MediaTypeFactory.java
+++ b/spring-web/src/main/java/org/springframework/http/MediaTypeFactory.java
@@ -77,7 +77,7 @@ public final class MediaTypeFactory {
 				String[] tokens = StringUtils.tokenizeToStringArray(line, " \t\n\r\f");
 				MediaType mediaType = MediaType.parseMediaType(tokens[0]);
 				for (int i = 1; i < tokens.length; i++) {
-					String fileExtension = tokens[i].toLowerCase(Locale.ENGLISH);
+					String fileExtension = tokens[i].toLowerCase(Locale.ROOT);
 					result.add(fileExtension, mediaType);
 				}
 			}
@@ -117,7 +117,7 @@ public final class MediaTypeFactory {
 		List<MediaType> mediaTypes = null;
 		String ext = StringUtils.getFilenameExtension(filename);
 		if (ext != null) {
-			mediaTypes = fileExtensionToMediaTypes.get(ext.toLowerCase(Locale.ENGLISH));
+			mediaTypes = fileExtensionToMediaTypes.get(ext.toLowerCase(Locale.ROOT));
 		}
 		return (mediaTypes != null ? mediaTypes : Collections.emptyList());
 	}

--- a/spring-web/src/main/java/org/springframework/http/server/reactive/ServletServerHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/ServletServerHttpRequest.java
@@ -107,7 +107,7 @@ class ServletServerHttpRequest extends AbstractServerHttpRequest {
 
 	private static MultiValueMap<String, String> createDefaultHttpHeaders(HttpServletRequest request) {
 		MultiValueMap<String, String> headers =
-				CollectionUtils.toMultiValueMap(new LinkedCaseInsensitiveMap<>(8, Locale.ENGLISH));
+				CollectionUtils.toMultiValueMap(new LinkedCaseInsensitiveMap<>(8, Locale.ROOT));
 		for (Enumeration<?> names = request.getHeaderNames(); names.hasMoreElements(); ) {
 			String name = (String) names.nextElement();
 			for (Enumeration<?> values = request.getHeaders(name); values.hasMoreElements(); ) {

--- a/spring-web/src/main/java/org/springframework/remoting/httpinvoker/HttpComponentsHttpInvokerRequestExecutor.java
+++ b/spring-web/src/main/java/org/springframework/remoting/httpinvoker/HttpComponentsHttpInvokerRequestExecutor.java
@@ -364,7 +364,7 @@ public class HttpComponentsHttpInvokerRequestExecutor extends AbstractHttpInvoke
 	protected boolean isGzipResponse(HttpResponse httpResponse) {
 		Header encodingHeader = httpResponse.getFirstHeader(HTTP_HEADER_CONTENT_ENCODING);
 		return (encodingHeader != null && encodingHeader.getValue() != null &&
-				encodingHeader.getValue().toLowerCase().contains(ENCODING_GZIP));
+				encodingHeader.getValue().toLowerCase(Locale.ROOT).contains(ENCODING_GZIP));
 	}
 
 }

--- a/spring-web/src/main/java/org/springframework/remoting/httpinvoker/SimpleHttpInvokerRequestExecutor.java
+++ b/spring-web/src/main/java/org/springframework/remoting/httpinvoker/SimpleHttpInvokerRequestExecutor.java
@@ -227,7 +227,7 @@ public class SimpleHttpInvokerRequestExecutor extends AbstractHttpInvokerRequest
 	 */
 	protected boolean isGzipResponse(HttpURLConnection con) {
 		String encodingHeader = con.getHeaderField(HTTP_HEADER_CONTENT_ENCODING);
-		return (encodingHeader != null && encodingHeader.toLowerCase().contains(ENCODING_GZIP));
+		return (encodingHeader != null && encodingHeader.toLowerCase(Locale.ROOT).contains(ENCODING_GZIP));
 	}
 
 }

--- a/spring-web/src/main/java/org/springframework/web/accept/ContentNegotiationManagerFactoryBean.java
+++ b/spring-web/src/main/java/org/springframework/web/accept/ContentNegotiationManagerFactoryBean.java
@@ -214,7 +214,7 @@ public class ContentNegotiationManagerFactoryBean
 	 * An alternative to {@link #setMediaTypes} for programmatic registrations.
 	 */
 	public void addMediaType(String key, MediaType mediaType) {
-		this.mediaTypes.put(key.toLowerCase(Locale.ENGLISH), mediaType);
+		this.mediaTypes.put(key.toLowerCase(Locale.ROOT), mediaType);
 	}
 
 	/**

--- a/spring-web/src/main/java/org/springframework/web/accept/MappingMediaTypeFileExtensionResolver.java
+++ b/spring-web/src/main/java/org/springframework/web/accept/MappingMediaTypeFileExtensionResolver.java
@@ -57,7 +57,7 @@ public class MappingMediaTypeFileExtensionResolver implements MediaTypeFileExten
 		if (mediaTypes != null) {
 			Set<String> allFileExtensions = new HashSet<>(mediaTypes.size());
 			mediaTypes.forEach((extension, mediaType) -> {
-				String lowerCaseExtension = extension.toLowerCase(Locale.ENGLISH);
+				String lowerCaseExtension = extension.toLowerCase(Locale.ROOT);
 				this.mediaTypes.put(lowerCaseExtension, mediaType);
 				addFileExtension(mediaType, lowerCaseExtension);
 				allFileExtensions.add(lowerCaseExtension);
@@ -109,7 +109,7 @@ public class MappingMediaTypeFileExtensionResolver implements MediaTypeFileExten
 	 */
 	@Nullable
 	protected MediaType lookupMediaType(String extension) {
-		return this.mediaTypes.get(extension.toLowerCase(Locale.ENGLISH));
+		return this.mediaTypes.get(extension.toLowerCase(Locale.ROOT);
 	}
 
 }

--- a/spring-web/src/main/java/org/springframework/web/accept/PathExtensionContentNegotiationStrategy.java
+++ b/spring-web/src/main/java/org/springframework/web/accept/PathExtensionContentNegotiationStrategy.java
@@ -99,7 +99,7 @@ public class PathExtensionContentNegotiationStrategy extends AbstractMappingCont
 		// Ignore LOOKUP_PATH attribute, use our own "fixed" UrlPathHelper with decoding off
 		String path = this.urlPathHelper.getLookupPathForRequest(request);
 		String extension = UriUtils.extractFileExtension(path);
-		return (StringUtils.hasText(extension) ? extension.toLowerCase(Locale.ENGLISH) : null);
+		return (StringUtils.hasText(extension) ? extension.toLowerCase(Locale.ROOT) : null);
 	}
 
 	/**

--- a/spring-web/src/main/java/org/springframework/web/filter/ForwardedHeaderFilter.java
+++ b/spring-web/src/main/java/org/springframework/web/filter/ForwardedHeaderFilter.java
@@ -73,7 +73,7 @@ import org.springframework.web.util.UrlPathHelper;
 public class ForwardedHeaderFilter extends OncePerRequestFilter {
 
 	private static final Set<String> FORWARDED_HEADER_NAMES =
-			Collections.newSetFromMap(new LinkedCaseInsensitiveMap<>(10, Locale.ENGLISH));
+			Collections.newSetFromMap(new LinkedCaseInsensitiveMap<>(10, Locale.ROOT));
 
 	static {
 		FORWARDED_HEADER_NAMES.add("Forwarded");
@@ -177,7 +177,7 @@ public class ForwardedHeaderFilter extends OncePerRequestFilter {
 		}
 
 		private static Map<String, List<String>> initHeaders(HttpServletRequest request) {
-			Map<String, List<String>> headers = new LinkedCaseInsensitiveMap<>(Locale.ENGLISH);
+			Map<String, List<String>> headers = new LinkedCaseInsensitiveMap<>(Locale.ROOT);
 			Enumeration<String> names = request.getHeaderNames();
 			while (names.hasMoreElements()) {
 				String name = names.nextElement();

--- a/spring-web/src/main/java/org/springframework/web/filter/HiddenHttpMethodFilter.java
+++ b/spring-web/src/main/java/org/springframework/web/filter/HiddenHttpMethodFilter.java
@@ -84,7 +84,7 @@ public class HiddenHttpMethodFilter extends OncePerRequestFilter {
 		if ("POST".equals(request.getMethod()) && request.getAttribute(WebUtils.ERROR_EXCEPTION_ATTRIBUTE) == null) {
 			String paramValue = request.getParameter(this.methodParam);
 			if (StringUtils.hasLength(paramValue)) {
-				String method = paramValue.toUpperCase(Locale.ENGLISH);
+				String method = paramValue.toUpperCase(Locale.ROOT);
 				if (ALLOWED_METHODS.contains(method)) {
 					requestToUse = new HttpMethodRequestWrapper(request, method);
 				}

--- a/spring-web/src/main/java/org/springframework/web/filter/reactive/HiddenHttpMethodFilter.java
+++ b/spring-web/src/main/java/org/springframework/web/filter/reactive/HiddenHttpMethodFilter.java
@@ -91,7 +91,7 @@ public class HiddenHttpMethodFilter implements WebFilter {
 	}
 
 	private ServerWebExchange mapExchange(ServerWebExchange exchange, String methodParamValue) {
-		HttpMethod httpMethod = HttpMethod.resolve(methodParamValue.toUpperCase(Locale.ENGLISH));
+		HttpMethod httpMethod = HttpMethod.resolve(methodParamValue.toUpperCase(Locale.ROOT));
 		Assert.notNull(httpMethod, () -> "HttpMethod '" + methodParamValue + "' not supported");
 		if (ALLOWED_METHODS.contains(httpMethod)) {
 			return exchange.mutate().request(builder -> builder.method(httpMethod)).build();

--- a/spring-web/src/main/java/org/springframework/web/multipart/support/MultipartResolutionDelegate.java
+++ b/spring-web/src/main/java/org/springframework/web/multipart/support/MultipartResolutionDelegate.java
@@ -19,6 +19,7 @@ package org.springframework.web.multipart.support;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.Part;
@@ -71,7 +72,7 @@ public final class MultipartResolutionDelegate {
 
 	private static boolean isMultipartContent(HttpServletRequest request) {
 		String contentType = request.getContentType();
-		return (contentType != null && contentType.toLowerCase().startsWith("multipart/"));
+		return (contentType != null && contentType.toLowerCase(Locale.ROOT).startsWith("multipart/"));
 	}
 
 	static MultipartHttpServletRequest asMultipartHttpServletRequest(HttpServletRequest request) {

--- a/spring-web/src/main/java/org/springframework/web/multipart/support/StandardMultipartHttpServletRequest.java
+++ b/spring-web/src/main/java/org/springframework/web/multipart/support/StandardMultipartHttpServletRequest.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -119,7 +120,7 @@ public class StandardMultipartHttpServletRequest extends AbstractMultipartHttpSe
 	protected void handleParseFailure(Throwable ex) {
 		String msg = ex.getMessage();
 		if (msg != null) {
-			msg = msg.toLowerCase();
+			msg = msg.toLowerCase(Locale.ROOT);
 			if (msg.contains("size") && msg.contains("exceed")) {
 				throw new MaxUploadSizeExceededException(-1, ex);
 			}

--- a/spring-web/src/main/java/org/springframework/web/server/adapter/ForwardedHeaderTransformer.java
+++ b/spring-web/src/main/java/org/springframework/web/server/adapter/ForwardedHeaderTransformer.java
@@ -57,7 +57,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 public class ForwardedHeaderTransformer implements Function<ServerHttpRequest, ServerHttpRequest> {
 
 	static final Set<String> FORWARDED_HEADER_NAMES =
-			Collections.newSetFromMap(new LinkedCaseInsensitiveMap<>(10, Locale.ENGLISH));
+			Collections.newSetFromMap(new LinkedCaseInsensitiveMap<>(10, Locale.ROOT));
 
 	static {
 		FORWARDED_HEADER_NAMES.add("Forwarded");

--- a/spring-web/src/main/java/org/springframework/web/server/adapter/HttpWebHandlerAdapter.java
+++ b/spring-web/src/main/java/org/springframework/web/server/adapter/HttpWebHandlerAdapter.java
@@ -18,6 +18,7 @@ package org.springframework.web.server.adapter;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
 
 import org.apache.commons.logging.Log;
@@ -314,7 +315,7 @@ public class HttpWebHandlerAdapter extends WebHandlerDecorator implements HttpHa
 	private boolean isDisconnectedClientError(Throwable ex) {
 		String message = NestedExceptionUtils.getMostSpecificCause(ex).getMessage();
 		if (message != null) {
-			String text = message.toLowerCase();
+			String text = message.toLowerCase(Locale.ROOT);
 			if (text.contains("broken pipe") || text.contains("connection reset by peer")) {
 				return true;
 			}

--- a/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Matcher;
@@ -291,7 +292,7 @@ public class UriComponentsBuilder implements UriBuilder, Cloneable {
 		if (matcher.matches()) {
 			UriComponentsBuilder builder = new UriComponentsBuilder();
 			String scheme = matcher.group(1);
-			builder.scheme(scheme != null ? scheme.toLowerCase() : null);
+			builder.scheme(scheme != null ? scheme.toLowerCase(Locale.ROOT) : null);
 			builder.userInfo(matcher.group(4));
 			String host = matcher.group(5);
 			checkSchemeAndHost(httpUrl, scheme, host);

--- a/spring-web/src/main/java/org/springframework/web/util/UrlPathHelper.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UrlPathHelper.java
@@ -18,6 +18,7 @@ package org.springframework.web.util;
 
 import java.net.URLDecoder;
 import java.nio.charset.UnsupportedCharsetException;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 
@@ -635,7 +636,7 @@ public class UrlPathHelper {
 
 	private String removeJsessionid(String requestUri) {
 		String key = ";jsessionid=";
-		int index = requestUri.toLowerCase().indexOf(key);
+		int index = requestUri.toLowerCase(Locale.ROOT).indexOf(key);
 		if (index == -1) {
 			return requestUri;
 		}

--- a/spring-web/src/test/java/org/springframework/http/client/AbstractAsyncHttpRequestFactoryTests.java
+++ b/spring-web/src/test/java/org/springframework/http/client/AbstractAsyncHttpRequestFactoryTests.java
@@ -187,7 +187,7 @@ public abstract class AbstractAsyncHttpRequestFactoryTests extends AbstractMockW
 		Future<ClientHttpResponse> futureResponse = request.executeAsync();
 		try (ClientHttpResponse response = futureResponse.get()) {
 			assertThat(response.getStatusCode()).as("Invalid response status").isEqualTo(HttpStatus.OK);
-			assertThat(request.getMethod().name()).as("Invalid method").isEqualTo(path.toUpperCase(Locale.ENGLISH));
+			assertThat(request.getMethod().name()).as("Invalid method").isEqualTo(path.toUpperCase(Locale.ROOT));
 		}
 	}
 

--- a/spring-web/src/test/java/org/springframework/http/client/AbstractHttpRequestFactoryTests.java
+++ b/spring-web/src/test/java/org/springframework/http/client/AbstractHttpRequestFactoryTests.java
@@ -167,7 +167,7 @@ abstract class AbstractHttpRequestFactoryTests extends AbstractMockWebServerTest
 
 		try (ClientHttpResponse response = request.execute()) {
 			assertThat(response.getStatusCode()).as("Invalid response status").isEqualTo(HttpStatus.OK);
-			assertThat(request.getMethod().name()).as("Invalid method").isEqualTo(path.toUpperCase(Locale.ENGLISH));
+			assertThat(request.getMethod().name()).as("Invalid method").isEqualTo(path.toUpperCase(Locale.ROOT));
 		}
 	}
 

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/accept/ParameterContentTypeResolver.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/accept/ParameterContentTypeResolver.java
@@ -51,7 +51,7 @@ public class ParameterContentTypeResolver implements RequestedContentTypeResolve
 	}
 
 	private static String formatKey(String key) {
-		return key.toLowerCase(Locale.ENGLISH);
+		return key.toLowerCase(Locale.ROOT);
 	}
 
 

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/resource/CachingResourceResolver.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/resource/CachingResourceResolver.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
 
 import reactor.core.publisher.Mono;
@@ -140,7 +141,7 @@ public class CachingResourceResolver extends AbstractResourceResolver {
 		return Arrays.stream(StringUtils.tokenizeToStringArray(header, ","))
 				.map(token -> {
 					int index = token.indexOf(';');
-					return (index >= 0 ? token.substring(0, index) : token).trim().toLowerCase();
+					return (index >= 0 ? token.substring(0, index) : token).trim().toLowerCase(Locale.ROOT);
 				})
 				.filter(this.contentCodings::contains)
 				.sorted()

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/resource/EncodedResourceResolver.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/resource/EncodedResourceResolver.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import reactor.core.publisher.Mono;
@@ -168,7 +169,7 @@ public class EncodedResourceResolver extends AbstractResourceResolver {
 	private String getAcceptEncoding(ServerWebExchange exchange) {
 		ServerHttpRequest request = exchange.getRequest();
 		String header = request.getHeaders().getFirst(HttpHeaders.ACCEPT_ENCODING);
-		return (header != null ? header.toLowerCase() : null);
+		return (header != null ? header.toLowerCase(Locale.ROOT) : null);
 	}
 
 	private String getExtension(String coding) {

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/resource/GzipResourceResolver.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/resource/GzipResourceResolver.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URL;
 import java.util.List;
+import java.util.Locale;
 
 import reactor.core.publisher.Mono;
 
@@ -69,7 +70,7 @@ public class GzipResourceResolver extends AbstractResourceResolver {
 
 	private boolean isGzipAccepted(ServerWebExchange exchange) {
 		String value = exchange.getRequest().getHeaders().getFirst("Accept-Encoding");
-		return (value != null && value.toLowerCase().contains("gzip"));
+		return (value != null && value.toLowerCase(Locale.ROOT).contains("gzip"));
 	}
 
 	@Override

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/resource/ResourceWebHandler.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/resource/ResourceWebHandler.java
@@ -315,7 +315,7 @@ public class ResourceWebHandler implements WebHandler, InitializingBean {
 			this.mediaTypes = new HashMap<>(mediaTypes.size());
 		}
 		mediaTypes.forEach((ext, type) ->
-				this.mediaTypes.put(ext.toLowerCase(Locale.ENGLISH), type));
+				this.mediaTypes.put(ext.toLowerCase(Locale.ROOT), type));
 	}
 
 	/**
@@ -605,7 +605,7 @@ public class ResourceWebHandler implements WebHandler, InitializingBean {
 		if (!CollectionUtils.isEmpty(this.mediaTypes)) {
 			String ext = StringUtils.getFilenameExtension(filename);
 			if (ext != null) {
-				mediaType = this.mediaTypes.get(ext.toLowerCase(Locale.ENGLISH));
+				mediaType = this.mediaTypes.get(ext.toLowerCase(Locale.ROOT);
 			}
 		}
 		if (mediaType == null) {

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/condition/AbstractNameValueExpression.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/condition/AbstractNameValueExpression.java
@@ -16,6 +16,8 @@
 
 package org.springframework.web.reactive.result.condition;
 
+import java.util.Locale;
+
 import org.springframework.lang.Nullable;
 import org.springframework.util.ObjectUtils;
 import org.springframework.web.server.ServerWebExchange;
@@ -106,7 +108,7 @@ abstract class AbstractNameValueExpression<T> implements NameValueExpression<T> 
 
 	@Override
 	public int hashCode() {
-		int result = (isCaseSensitiveName() ? this.name : this.name.toLowerCase()).hashCode();
+		int result = (isCaseSensitiveName() ? this.name : this.name.toLowerCase(Locale.ROOT)).hashCode();
 		result = 31 * result + ObjectUtils.nullSafeHashCode(this.value);
 		result = 31 * result + (this.isNegated ? 1 : 0);
 		return result;

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/condition/AbstractNameValueExpression.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/condition/AbstractNameValueExpression.java
@@ -16,6 +16,8 @@
 
 package org.springframework.web.servlet.mvc.condition;
 
+import java.util.Locale;
+
 import javax.servlet.http.HttpServletRequest;
 
 import org.springframework.lang.Nullable;
@@ -108,7 +110,7 @@ abstract class AbstractNameValueExpression<T> implements NameValueExpression<T> 
 
 	@Override
 	public int hashCode() {
-		int result = (isCaseSensitiveName() ? this.name.hashCode() : this.name.toLowerCase().hashCode());
+		int result = (isCaseSensitiveName() ? this.name.hashCode() : this.name.toLowerCase(Locale.ROOT).hashCode());
 		result = 31 * result + (this.value != null ? this.value.hashCode() : 0);
 		result = 31 * result + (this.isNegated ? 1 : 0);
 		return result;

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/AbstractMessageConverterMethodProcessor.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/AbstractMessageConverterMethodProcessor.java
@@ -456,7 +456,7 @@ public abstract class AbstractMessageConverterMethodProcessor extends AbstractMe
 		if (!StringUtils.hasText(extension)) {
 			return true;
 		}
-		extension = extension.toLowerCase(Locale.ENGLISH);
+		extension = extension.toLowerCase(Locale.ROOT);
 		if (this.safeExtensions.contains(extension)) {
 			return true;
 		}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/CachingResourceResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/CachingResourceResolver.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
@@ -146,7 +147,7 @@ public class CachingResourceResolver extends AbstractResourceResolver {
 		return Arrays.stream(StringUtils.tokenizeToStringArray(header, ","))
 				.map(token -> {
 					int index = token.indexOf(';');
-					return (index >= 0 ? token.substring(0, index) : token).trim().toLowerCase();
+						return (index >= 0 ? token.substring(0, index) : token).trim().toLowerCase(Locale.ROOT);
 				})
 				.filter(this.contentCodings::contains)
 				.sorted()

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/EncodedResourceResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/EncodedResourceResolver.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
@@ -164,7 +165,7 @@ public class EncodedResourceResolver extends AbstractResourceResolver {
 	@Nullable
 	private String getAcceptEncoding(HttpServletRequest request) {
 		String header = request.getHeader(HttpHeaders.ACCEPT_ENCODING);
-		return (header != null ? header.toLowerCase() : null);
+		return (header != null ? header.toLowerCase(Locale.ROOT) : null);
 	}
 
 	private String getExtension(String coding) {

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/GzipResourceResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/GzipResourceResolver.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URL;
 import java.util.List;
+import java.util.Locale;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -70,7 +71,7 @@ public class GzipResourceResolver extends AbstractResourceResolver {
 
 	private boolean isGzipAccepted(HttpServletRequest request) {
 		String value = request.getHeader("Accept-Encoding");
-		return (value != null && value.toLowerCase().contains("gzip"));
+		return (value != null && value.toLowerCase(Locale.ROOT).contains("gzip"));
 	}
 
 	@Override

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/ResourceHttpRequestHandler.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/ResourceHttpRequestHandler.java
@@ -317,7 +317,7 @@ public class ResourceHttpRequestHandler extends WebContentGenerator
 	 */
 	public void setMediaTypes(Map<String, MediaType> mediaTypes) {
 		mediaTypes.forEach((ext, mediaType) ->
-				this.mediaTypes.put(ext.toLowerCase(Locale.ENGLISH), mediaType));
+				this.mediaTypes.put(ext.toLowerCase(Locale.ROOT), mediaType));
 	}
 
 	/**
@@ -786,7 +786,7 @@ public class ResourceHttpRequestHandler extends WebContentGenerator
 			String filename = resource.getFilename();
 			String ext = StringUtils.getFilenameExtension(filename);
 			if (ext != null) {
-				mediaType = this.mediaTypes.get(ext.toLowerCase(Locale.ENGLISH));
+				mediaType = this.mediaTypes.get(ext.toLowerCase(Locale.ROOT);
 			}
 			if (mediaType == null) {
 				List<MediaType> mediaTypes = MediaTypeFactory.getMediaTypes(filename);

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/xslt/XsltView.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/xslt/XsltView.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.util.Enumeration;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 
@@ -415,7 +416,7 @@ public class XsltView extends AbstractUrlBasedView {
 		}
 		if (StringUtils.hasText(encoding)) {
 			// Only apply encoding if content type is specified but does not contain charset clause already.
-			if (contentType != null && !contentType.toLowerCase().contains(WebUtils.CONTENT_TYPE_CHARSET_PREFIX)) {
+			if (contentType != null && !contentType.toLowerCase(Locale.ROOT).contains(WebUtils.CONTENT_TYPE_CHARSET_PREFIX)) {
 				contentType = contentType + WebUtils.CONTENT_TYPE_CHARSET_PREFIX + encoding;
 			}
 		}

--- a/spring-websocket/src/main/java/org/springframework/web/socket/WebSocketExtension.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/WebSocketExtension.java
@@ -72,7 +72,7 @@ public class WebSocketExtension {
 		Assert.hasLength(name, "Extension name must not be empty");
 		this.name = name;
 		if (!CollectionUtils.isEmpty(parameters)) {
-			Map<String, String> map = new LinkedCaseInsensitiveMap<>(parameters.size(), Locale.ENGLISH);
+			Map<String, String> map = new LinkedCaseInsensitiveMap<>(parameters.size(), Locale.ROOT);
 			map.putAll(parameters);
 			this.parameters = Collections.unmodifiableMap(map);
 		}

--- a/spring-websocket/src/main/java/org/springframework/web/socket/adapter/standard/StandardToWebSocketExtensionAdapter.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/adapter/standard/StandardToWebSocketExtensionAdapter.java
@@ -42,7 +42,7 @@ public class StandardToWebSocketExtensionAdapter extends WebSocketExtension {
 
 	private static Map<String, String> initParameters(Extension extension) {
 		List<Extension.Parameter> parameters = extension.getParameters();
-		Map<String, String> result = new LinkedCaseInsensitiveMap<>(parameters.size(), Locale.ENGLISH);
+		Map<String, String> result = new LinkedCaseInsensitiveMap<>(parameters.size(), Locale.ROOT);
 		for (Extension.Parameter parameter : parameters) {
 			result.put(parameter.getName(), parameter.getValue());
 		}

--- a/spring-websocket/src/main/java/org/springframework/web/socket/client/AbstractWebSocketClient.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/client/AbstractWebSocketClient.java
@@ -20,6 +20,7 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -85,7 +86,7 @@ public abstract class AbstractWebSocketClient implements WebSocketClient {
 		HttpHeaders headersToUse = new HttpHeaders();
 		if (headers != null) {
 			headers.forEach((header, values) -> {
-				if (values != null && !specialHeaders.contains(header.toLowerCase())) {
+				if (values != null && !specialHeaders.contains(header.toLowerCase(Locale.ROOT))) {
 					headersToUse.put(header, values);
 				}
 			});

--- a/spring-websocket/src/main/java/org/springframework/web/socket/client/standard/StandardWebSocketClient.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/client/standard/StandardWebSocketClient.java
@@ -181,7 +181,7 @@ public class StandardWebSocketClient extends AbstractWebSocketClient {
 
 	private int getPort(URI uri) {
 		if (uri.getPort() == -1) {
-			String scheme = uri.getScheme().toLowerCase(Locale.ENGLISH);
+			String scheme = uri.getScheme().toLowerCase(Locale.ROOT);
 			return ("wss".equals(scheme) ? 443 : 80);
 		}
 		return uri.getPort();

--- a/spring-websocket/src/main/java/org/springframework/web/socket/server/support/AbstractHandshakeHandler.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/server/support/AbstractHandshakeHandler.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.apache.commons.logging.Log;
@@ -192,7 +193,7 @@ public abstract class AbstractHandshakeHandler implements HandshakeHandler, Life
 	public void setSupportedProtocols(String... protocols) {
 		this.supportedProtocols.clear();
 		for (String protocol : protocols) {
-			this.supportedProtocols.add(protocol.toLowerCase());
+			this.supportedProtocols.add(protocol.toLowerCase(Locale.ROOT));
 		}
 	}
 
@@ -367,10 +368,10 @@ public abstract class AbstractHandshakeHandler implements HandshakeHandler, Life
 	protected String selectProtocol(List<String> requestedProtocols, WebSocketHandler webSocketHandler) {
 		List<String> handlerProtocols = determineHandlerSupportedProtocols(webSocketHandler);
 		for (String protocol : requestedProtocols) {
-			if (handlerProtocols.contains(protocol.toLowerCase())) {
+			if (handlerProtocols.contains(protocol.toLowerCase(Locale.ROOT))) {
 				return protocol;
 			}
-			if (this.supportedProtocols.contains(protocol.toLowerCase())) {
+			if (this.supportedProtocols.contains(protocol.toLowerCase(Locale.ROOT))) {
 				return protocol;
 			}
 		}

--- a/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/frame/AbstractSockJsMessageCodec.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/frame/AbstractSockJsMessageCodec.java
@@ -16,6 +16,8 @@
 
 package org.springframework.web.socket.sockjs.frame;
 
+import java.util.Locale;
+
 import org.springframework.util.Assert;
 
 /**
@@ -58,7 +60,7 @@ public abstract class AbstractSockJsMessageCodec implements SockJsMessageCodec {
 		for (char c : characters) {
 			if (isSockJsSpecialChar(c)) {
 				result.append('\\').append('u');
-				String hex = Integer.toHexString(c).toLowerCase();
+				String hex = Integer.toHexString(c).toLowerCase(Locale.ROOT);
 				for (int i = 0; i < (4 - hex.length()); i++) {
 					result.append('0');
 				}

--- a/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/transport/session/AbstractSockJsSession.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/transport/session/AbstractSockJsSession.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -364,7 +365,7 @@ public abstract class AbstractSockJsSession implements SockJsSession {
 
 	private boolean indicatesDisconnectedClient(Throwable ex)  {
 		String message = NestedExceptionUtils.getMostSpecificCause(ex).getMessage();
-		message = (message != null ? message.toLowerCase() : "");
+		message = (message != null ? message.toLowerCase(Locale.ROOT) : "");
 		String className = ex.getClass().getSimpleName();
 		return (message.contains("broken pipe") || DISCONNECTED_CLIENT_EXCEPTIONS.contains(className));
 	}

--- a/src/docs/asciidoc/testing.adoc
+++ b/src/docs/asciidoc/testing.adoc
@@ -2002,7 +2002,7 @@ test methods within that class are automatically disabled as well.
 Expressions can be any of the following:
 
 * <<core.adoc#expressions, Spring Expression Language>> (SpEL) expression. For example:
-  `@DisabledIf("#{systemProperties['os.name'].toLowerCase().contains('mac')}")`
+  `@DisabledIf("#{systemProperties['os.name'].toLowerCase(Locale.ROOT).contains('mac')}")`
 * Placeholder for a property available in the Spring <<core.adoc#beans-environment, `Environment`>>.
   For example: `@DisabledIf("${smoke.tests.disabled}")`
 * Text literal. For example: `@DisabledIf("true")`


### PR DESCRIPTION
### Purpose
$subject

**Changed**

- toUpperCase() --> toUpperCase(Locale.ROOT)
- toLowerCase()  --> toLowerCase(Locale.ROOT)
- toLowerCase(Locale.English) --> toLowerCase(Locale.ROOT)
- Locale.English --> Locale.ROOT

**Ported from:**

- https://github.com/spring-projects/spring-framework/commit/23656aebc6c7d0f9faff1080981eb4d55eff296c
- https://github.com/spring-projects/spring-framework/commit/c765d03a596a2481b9aa159d1bdeeda851437729
- https://github.com/spring-projects/spring-framework/commit/11d4272ff48b4a4dabc4b28dfbff0364a4204bc9

**Additional files changed:**

- spring-web/src/test/java/org/springframework/http/client/AbstractAsyncHttpRequestFactoryTests.java - **file not found** in master or original commits
- spring-web/src/main/java/org/springframework/remoting/httpinvoker/HttpComponentsHttpInvokerRequestExecutor.java - **file not found** in master or original commits
- spring-web/src/main/java/org/springframework/remoting/httpinvoker/SimpleHttpInvokerRequestExecutor.java - **file not found** in master or original commits
- spring-webflux/src/main/java/org/springframework/web/reactive/resource/GzipResourceResolver.java - **file not found** in master or original commits
- spring-webmvc/src/main/java/org/springframework/web/servlet/resource/GzipResourceResolver.java - **file not found** in master or original commits
- spring-context/src/main/java/org/springframework/scheduling/support/CronSequenceGenerator.java  - **file not found** in master or original commits
- spring-websocket/src/main/java/org/springframework/web/socket/sockjs/transport/session/AbstractSockJsSession.java - **method not found** in master or original commits
- spring-web/src/main/java/org/springframework/web/server/adapter/HttpWebHandlerAdapter.java - **method not found** in master or original commits

