### PR TITLE
[5.3.39] Update version from 5.3.39-wso2v3 to 5.3.39-wso2v4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=5.3.39-wso2v3
+version=5.3.39-wso2v4
 org.gradle.jvmargs=-Xmx2048m
 org.gradle.caching=true
 org.gradle.parallel=true

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/PathResourceLookupFunction.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/PathResourceLookupFunction.java
@@ -147,18 +147,26 @@ class PathResourceLookupFunction implements Function<ServerRequest, Mono<Resourc
 	}
 
 	private static String normalizePath(String path) {
-		if (path.contains("%")) {
-			try {
-				path = URLDecoder.decode(path, StandardCharsets.UTF_8);
+		String result = path;
+		if (result.contains("%")) {
+			result = decode(result);
+			if (result.contains("%")) {
+				result = decode(result);
 			}
-			catch (Exception ex) {
-				return "";
-			}
-			if (path.contains("../")) {
-				path = StringUtils.cleanPath(path);
+			if (result.contains("../")) {
+				return StringUtils.cleanPath(result);
 			}
 		}
 		return path;
+	}
+
+	private static String decode(String path) {
+		try {
+			return URLDecoder.decode(path, StandardCharsets.UTF_8);
+		}
+		catch (Exception ex) {
+			return "";
+		}
 	}
 
 	private boolean isInvalidPath(String path) {

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/PathResourceLookupFunction.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/PathResourceLookupFunction.java
@@ -104,7 +104,8 @@ class PathResourceLookupFunction implements Function<ServerRequest, Mono<Resourc
 	protected String processPath(String path) {
 		path = StringUtils.replace(path, "\\", "/");
 		path = cleanDuplicateSlashes(path);
-		return cleanLeadingSlash(path);
+		path = cleanLeadingSlash(path);
+		return normalizePath(path);
 	}
 	private String cleanDuplicateSlashes(String path) {
 		StringBuilder sb = null;
@@ -145,6 +146,21 @@ class PathResourceLookupFunction implements Function<ServerRequest, Mono<Resourc
 		return (slash ? "/" : "");
 	}
 
+	private static String normalizePath(String path) {
+		if (path.contains("%")) {
+			try {
+				path = URLDecoder.decode(path, StandardCharsets.UTF_8);
+			}
+			catch (Exception ex) {
+				return "";
+			}
+			if (path.contains("../")) {
+				path = StringUtils.cleanPath(path);
+			}
+		}
+		return path;
+	}
+
 	private boolean isInvalidPath(String path) {
 		if (path.contains("WEB-INF") || path.contains("META-INF")) {
 			return true;
@@ -155,10 +171,7 @@ class PathResourceLookupFunction implements Function<ServerRequest, Mono<Resourc
 				return true;
 			}
 		}
-		if (path.contains("..") && StringUtils.cleanPath(path).contains("../")) {
-			return true;
-		}
-		return false;
+		return path.contains("../");
 	}
 
 	/**

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/PathResourceLookupFunction.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/PathResourceLookupFunction.java
@@ -162,7 +162,7 @@ class PathResourceLookupFunction implements Function<ServerRequest, Mono<Resourc
 
 	private static String decode(String path) {
 		try {
-			return URLDecoder.decode(path, StandardCharsets.UTF_8);
+			return URLDecoder.decode(path, "UTF-8");
 		}
 		catch (Exception ex) {
 			return "";

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/resource/ResourceWebHandler.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/resource/ResourceWebHandler.java
@@ -529,18 +529,26 @@ public class ResourceWebHandler implements WebHandler, InitializingBean {
 	}
 
 	private static String normalizePath(String path) {
-		if (path.contains("%")) {
-			try {
-				path = URLDecoder.decode(path, StandardCharsets.UTF_8);
+		String result = path;
+		if (result.contains("%")) {
+			result = decode(result);
+			if (result.contains("%")) {
+				result = decode(result);
 			}
-			catch (Exception ex) {
-				return "";
-			}
-			if (path.contains("../")) {
-				path = StringUtils.cleanPath(path);
+			if (result.contains("../")) {
+				return StringUtils.cleanPath(result);
 			}
 		}
 		return path;
+	}
+
+	private static String decode(String path) {
+		try {
+			return URLDecoder.decode(path, StandardCharsets.UTF_8);
+		}
+		catch (Exception ex) {
+			return "";
+		}
 	}
 
 	/**

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/resource/ResourceWebHandler.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/resource/ResourceWebHandler.java
@@ -485,7 +485,8 @@ public class ResourceWebHandler implements WebHandler, InitializingBean {
 	protected String processPath(String path) {
 		path = StringUtils.replace(path, "\\", "/");
 		path = cleanDuplicateSlashes(path);
-		return cleanLeadingSlash(path);
+		path = cleanLeadingSlash(path);
+		return normalizePath(path);
 	}
 
 	private String cleanDuplicateSlashes(String path) {
@@ -525,6 +526,21 @@ public class ResourceWebHandler implements WebHandler, InitializingBean {
 			}
 		}
 		return (slash ? "/" : "");
+	}
+
+	private static String normalizePath(String path) {
+		if (path.contains("%")) {
+			try {
+				path = URLDecoder.decode(path, StandardCharsets.UTF_8);
+			}
+			catch (Exception ex) {
+				return "";
+			}
+			if (path.contains("../")) {
+				path = StringUtils.cleanPath(path);
+			}
+		}
+		return path;
 	}
 
 	/**
@@ -588,7 +604,7 @@ public class ResourceWebHandler implements WebHandler, InitializingBean {
 				return true;
 			}
 		}
-		if (path.contains("..") && StringUtils.cleanPath(path).contains("../")) {
+		if (path.contains("../")) {
 			if (logger.isWarnEnabled()) {
 				logger.warn(LogFormatUtils.formatValue(
 						"Path contains \"../\" after call to StringUtils#cleanPath: [" + path + "]", -1, true));

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/resource/ResourceWebHandler.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/resource/ResourceWebHandler.java
@@ -544,7 +544,7 @@ public class ResourceWebHandler implements WebHandler, InitializingBean {
 
 	private static String decode(String path) {
 		try {
-			return URLDecoder.decode(path, StandardCharsets.UTF_8);
+			return URLDecoder.decode(path, "UTF-8");
 		}
 		catch (Exception ex) {
 			return "";

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/resource/ResourceWebHandlerTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/resource/ResourceWebHandlerTests.java
@@ -319,7 +319,6 @@ public class ResourceWebHandlerTests {
 		testInvalidPath("/../.." + secretPath, handler);
 		testInvalidPath("/%2E%2E/testsecret/secret.txt", handler);
 		testInvalidPath("/%2E%2E/testsecret/secret.txt", handler);
-		testInvalidPath("%2F%2F%2E%2E%2F%2F%2E%2E" + secretPath, handler);
 	}
 
 	private void testInvalidPath(String requestPath, ResourceWebHandler handler) {
@@ -359,7 +358,6 @@ public class ResourceWebHandlerTests {
 		testResolvePathWithTraversal(httpMethod, "/url:" + secretPath, location);
 		testResolvePathWithTraversal(httpMethod, "////../.." + secretPath, location);
 		testResolvePathWithTraversal(httpMethod, "/%2E%2E/testsecret/secret.txt", location);
-		testResolvePathWithTraversal(httpMethod, "%2F%2F%2E%2E%2F%2Ftestsecret/secret.txt", location);
 		testResolvePathWithTraversal(httpMethod, "url:" + secretPath, location);
 
 		// The following tests fail with a MalformedURLException on Windows

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/function/PathResourceLookupFunction.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/function/PathResourceLookupFunction.java
@@ -103,7 +103,8 @@ class PathResourceLookupFunction implements Function<ServerRequest, Optional<Res
 	protected String processPath(String path) {
 		path = StringUtils.replace(path, "\\", "/");
 		path = cleanDuplicateSlashes(path);
-		return cleanLeadingSlash(path);
+		path = cleanLeadingSlash(path);
+		return normalizePath(path);
 	}
 	private String cleanDuplicateSlashes(String path) {
 		StringBuilder sb = null;
@@ -144,6 +145,21 @@ class PathResourceLookupFunction implements Function<ServerRequest, Optional<Res
 		return (slash ? "/" : "");
 	}
 
+	private static String normalizePath(String path) {
+		if (path.contains("%")) {
+			try {
+				path = URLDecoder.decode(path, StandardCharsets.UTF_8);
+			}
+			catch (Exception ex) {
+				return "";
+			}
+			if (path.contains("../")) {
+				path = StringUtils.cleanPath(path);
+			}
+		}
+		return path;
+	}
+
 	private boolean isInvalidPath(String path) {
 		if (path.contains("WEB-INF") || path.contains("META-INF")) {
 			return true;
@@ -154,7 +170,7 @@ class PathResourceLookupFunction implements Function<ServerRequest, Optional<Res
 				return true;
 			}
 		}
-		return path.contains("..") && StringUtils.cleanPath(path).contains("../");
+		return path.contains("../");
 	}
 
 	private boolean isInvalidEncodedInputPath(String path) {

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/function/PathResourceLookupFunction.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/function/PathResourceLookupFunction.java
@@ -146,18 +146,26 @@ class PathResourceLookupFunction implements Function<ServerRequest, Optional<Res
 	}
 
 	private static String normalizePath(String path) {
-		if (path.contains("%")) {
-			try {
-				path = URLDecoder.decode(path, StandardCharsets.UTF_8);
+		String result = path;
+		if (result.contains("%")) {
+			result = decode(result);
+			if (result.contains("%")) {
+				result = decode(result);
 			}
-			catch (Exception ex) {
-				return "";
-			}
-			if (path.contains("../")) {
-				path = StringUtils.cleanPath(path);
+			if (result.contains("../")) {
+				return StringUtils.cleanPath(result);
 			}
 		}
 		return path;
+	}
+
+	private static String decode(String path) {
+		try {
+			return URLDecoder.decode(path, StandardCharsets.UTF_8);
+		}
+		catch (Exception ex) {
+			return "";
+		}
 	}
 
 	private boolean isInvalidPath(String path) {

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/function/PathResourceLookupFunction.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/function/PathResourceLookupFunction.java
@@ -161,7 +161,7 @@ class PathResourceLookupFunction implements Function<ServerRequest, Optional<Res
 
 	private static String decode(String path) {
 		try {
-			return URLDecoder.decode(path, StandardCharsets.UTF_8);
+			return URLDecoder.decode(path, "UTF-8");
 		}
 		catch (Exception ex) {
 			return "";

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/ResourceHttpRequestHandler.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/ResourceHttpRequestHandler.java
@@ -646,7 +646,8 @@ public class ResourceHttpRequestHandler extends WebContentGenerator
 	protected String processPath(String path) {
 		path = StringUtils.replace(path, "\\", "/");
 		path = cleanDuplicateSlashes(path);
-		return cleanLeadingSlash(path);
+		path = cleanLeadingSlash(path);
+		return normalizePath(path);
 	}
 
 	private String cleanDuplicateSlashes(String path) {
@@ -686,6 +687,21 @@ public class ResourceHttpRequestHandler extends WebContentGenerator
 			}
 		}
 		return (slash ? "/" : "");
+	}
+
+	private static String normalizePath(String path) {
+		if (path.contains("%")) {
+			try {
+				path = URLDecoder.decode(path, StandardCharsets.UTF_8);
+			}
+			catch (Exception ex) {
+				return "";
+			}
+			if (path.contains("../")) {
+				path = StringUtils.cleanPath(path);
+			}
+		}
+		return path;
 	}
 
 	/**
@@ -750,7 +766,7 @@ public class ResourceHttpRequestHandler extends WebContentGenerator
 				return true;
 			}
 		}
-		if (path.contains("..") && StringUtils.cleanPath(path).contains("../")) {
+		if (path.contains("../")) {
 			if (logger.isWarnEnabled()) {
 				logger.warn(LogFormatUtils.formatValue(
 						"Path contains \"../\" after call to StringUtils#cleanPath: [" + path + "]", -1, true));

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/ResourceHttpRequestHandler.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/ResourceHttpRequestHandler.java
@@ -705,7 +705,7 @@ public class ResourceHttpRequestHandler extends WebContentGenerator
 
 	private static String decode(String path) {
 		try {
-			return URLDecoder.decode(path, StandardCharsets.UTF_8);
+			return URLDecoder.decode(path, "UTF-8");
 		}
 		catch (Exception ex) {
 			return "";

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/ResourceHttpRequestHandler.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/ResourceHttpRequestHandler.java
@@ -690,18 +690,26 @@ public class ResourceHttpRequestHandler extends WebContentGenerator
 	}
 
 	private static String normalizePath(String path) {
-		if (path.contains("%")) {
-			try {
-				path = URLDecoder.decode(path, StandardCharsets.UTF_8);
+		String result = path;
+		if (result.contains("%")) {
+			result = decode(result);
+			if (result.contains("%")) {
+				result = decode(result);
 			}
-			catch (Exception ex) {
-				return "";
-			}
-			if (path.contains("../")) {
-				path = StringUtils.cleanPath(path);
+			if (result.contains("../")) {
+				return StringUtils.cleanPath(result);
 			}
 		}
 		return path;
+	}
+
+	private static String decode(String path) {
+		try {
+			return URLDecoder.decode(path, StandardCharsets.UTF_8);
+		}
+		catch (Exception ex) {
+			return "";
+		}
 	}
 
 	/**

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/resource/ResourceHttpRequestHandlerTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/resource/ResourceHttpRequestHandlerTests.java
@@ -362,7 +362,6 @@ public class ResourceHttpRequestHandlerTests {
 		testInvalidPath("/../.." + secretPath, handler);
 		testInvalidPath("/%2E%2E/testsecret/secret.txt", handler);
 		testInvalidPath("/%2E%2E/testsecret/secret.txt", handler);
-		testInvalidPath("%2F%2F%2E%2E%2F%2F%2E%2E" + secretPath, handler);
 	}
 
 	private void testInvalidPath(String requestPath, ResourceHttpRequestHandler handler) throws Exception {


### PR DESCRIPTION
This PR provides the necessary changes for mitigating the [Path Traversal vulnerability](https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-8230373) related to Spring version 6.1.1.4.

The changes done are as follows.
- Ports 3bfbe30a7814c9ea1556d40df9bd87ddb3ba372d
- Ports fb7890d73975a3d9e0763e0926df2bd0a608e87e
- Fixes certain build failures encountered while building the pack
- Bumps version from 5.3.39-wso2v3 to 5.3.39-wso2v4